### PR TITLE
fix: test undelegation and transfer

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -12,7 +12,7 @@ private_payments = "EnhkomtzKms55jXi3ijn9XsMKYpMT4BJjmbuDQmPo3YS"
 url = "https://api.apr.dev"
 
 [provider]
-cluster = "localnet"
+cluster = "devnet"
 wallet = "~/.config/solana/id.json"
 
 [scripts]


### PR DESCRIPTION
Closes #14 by testing undelegation and privacy enforcement against the devnet node

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated provider environment configuration from localnet to devnet.

* **Tests**
  * Enhanced transfer validation to verify deposit isolation across parties.
  * Added undelegate test with deposit ownership verification and automatic retry logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->