### PR TITLE
Fix incorrect `tokenMint`

### DIFF
--- a/frontend/hooks/use-simple-transfer.ts
+++ b/frontend/hooks/use-simple-transfer.ts
@@ -220,7 +220,7 @@ export default function useSimpleTransfer() {
               true,
               TOKEN_PROGRAM_ID,
             ),
-            tokenMint,
+            tokenMint: tokenMintPk,
             tokenProgram: TOKEN_PROGRAM_ID,
           })
           .instruction();


### PR DESCRIPTION
# Summary

## Problem
`modifyBalance` was receiving `tokenMint` as a string instead of a `PublicKey`, which could cause runtime failures during instruction execution.

## Fix
Replaced `tokenMint` with `tokenMintPk` when passing accounts to `modifyBalance`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal token mint handling in transfer operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->