### PR TITLE
fix: npm install command

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -3,7 +3,7 @@
 ### Npm
 
 ```bash
-npm run install
+npm install
 ```
 
 ```bash


### PR DESCRIPTION
## What has been fixed
- Replaced the incorrect command `npm run install` with the standard `npm install` in the “Getting Started” section

## Why
- `npm install` is the canonical command for installing dependencies
- `npm run install` only works if the “install” script is explicitly declared in `package.json`

## Notes
- The `yarn install` command has been left as is (it is correct, although you can simply use `yarn`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected npm installation command in README
  * Improved formatting in the Open Source section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->