### PR TITLE
Fix incorrect order of `waitForEphemeralAtaBalance` in transfer flow

### DIFF
--- a/hooks/use-simple-transfer.ts
+++ b/hooks/use-simple-transfer.ts
@@ -320,11 +320,13 @@ export default function useSimpleTransfer({
 
       for (const action of actions) {
         logger.debug(`Sending transaction ${action.name}:`, action);
+        
+        const signature = await action.connection.sendRawTransaction(action.signedTx!.serialize());
+        await action.callback?.(signature);
+
         if (action.name === 'ephemeralTx') {
           await waitForEphemeralAtaBalance(tokenAmount);
         }
-        const signature = await action.connection.sendRawTransaction(action.signedTx!.serialize());
-        await action.callback?.(signature);
       }
     },
     [


### PR DESCRIPTION
Previously, `waitForEphemeralAtaBalance` was called before sending the `ephemeralTx`.

This is logically incorrect because the ephemeral ATA balance can only change after the transaction is sent and confirmed. Calling the wait function beforehand could lead to unnecessary timeouts.

The `waitForEphemeralAtaBalance` call is now moved after `sendRawTransaction` and `confirmTransaction` for `ephemeralTx`, ensuring correct execution order:

`send` > `confirm` > `wait for state update`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction processing order to provide faster feedback on transaction submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->